### PR TITLE
fix: scope inline summary marker to session PID to prevent false matches

### DIFF
--- a/lib/hook_runner.sh
+++ b/lib/hook_runner.sh
@@ -235,11 +235,13 @@ case "${mode}" in
         [[ -z "${raw_prompt}" ]] && exit 0
         _dbg "raw_prompt=${raw_prompt}"
 
-        # Clear any stale status (e.g. the startup "Welcome back" message) so
-        # the monitor shows idle phrases until a tool-specific status is emitted.
+        # Write 💭 Thinking immediately so title transitions from any stale status
+        # (e.g. "Welcome back", "✅ Tests passed") as soon as the user submits.
+        # We write rather than clear so there is never an empty-status window that
+        # races with the async PreToolUse hook that fires right after this one.
         if [[ -n "${CCP_STATUS_FILE:-}" ]]; then
-            : > "${CCP_STATUS_FILE}" 2>/dev/null || true
-            _dbg "cleared status file on user-prompt"
+            atomic_write "${CCP_STATUS_FILE}" "💭 Thinking"
+            _dbg "wrote Thinking to status file on user-prompt"
         fi
 
         # Write first-5-words placeholder immediately so the title updates at once

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -131,7 +131,7 @@ setup_ccp_hooks() {
          ]) |
          .hooks.UserPromptSubmit = ((.hooks.UserPromptSubmit // []) + [
              {"_ccp_pid": $pid, "hooks": [
-                 {"type": "command", "command": ("bash \"" + $runner + "\" user-prompt"), "timeout": 5000, "async": false}
+                 {"type": "command", "command": ("bash \"" + $runner + "\" user-prompt"), "timeout": 5000, "async": true}
              ]}
          ]) |
          .hooks.Stop = ((.hooks.Stop // []) + [

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -321,7 +321,7 @@ result=$(echo '{"prompt":"Fix the login bug in the auth module"}' \
       bash "${LIB_DIR}/hook_runner.sh" user-prompt && cat "${TMP_CONTEXT}" 2>/dev/null || true)
 assert_contains "user-prompt writes context"        "Fix the login bug"  "${result}"
 result=$(cat "${TMP_STATUS}" 2>/dev/null || true)
-assert_empty "user-prompt does not touch status file (shows idle phrase)" "${result}"
+assert_equals "user-prompt writes 💭 Thinking to status file" "💭 Thinking" "${result}"
 
 # user-prompt: no trailing newline (exactly how Claude Code sends hook payloads)
 rm -f "${TMP_CONTEXT}" "${TMP_STATUS}"


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during real-world testing of the inline AI context summarization path (`--ai-context-strategy inline`).

- **PID-scoped summary marker** — The `CCP_TASK_SUMMARY:` regex was matching source code content when Claude read/grepped `bin/ccp` or `hook_runner.sh`, overwriting the real summary with raw instruction text. Fix: scope the marker to the session PID (`CCP_TASK_SUMMARY_<pid>:`) so source files on disk (which contain the unscoped template) never false-match. Closes #17.

- **JSON bleed in inline summary capture** — `tool_response` extraction used `jq tostring` on the full response object, so the regex captured `Check Outstanding Work","stderr":"","interrupted":false,...}` instead of just `Check Outstanding Work`. Fix: extract `.stdout` from the object when `tool_response` is a JSON object.

- **UserPromptSubmit hook error** — `async: false` was introduced to prevent a status-clear race condition, but blocking `UserPromptSubmit` hooks must write a JSON decision to stdout; since ccp writes nothing to stdout, Claude Code reported a hook error on every prompt. Fix: revert to `async: true` and write `💭 Thinking` to the status file instead of clearing it — eliminates the race without requiring a blocking hook. Closes #19.

## Test plan

- [x] All 134 tests pass (`bash tests/test-suite.sh`)
- [x] `shellcheck` clean
- [x] Install smoke test passes (`./install.sh`)
- [x] Real-world test: inline summary captured correctly without JSON bleed (verified in screenshot)
- [x] `UserPromptSubmit hook error` no longer appears in Claude Code UI
- [x] Title bar shows `💭 Thinking` immediately on prompt submit, transitions to tool-specific status

🤖 Generated with [Claude Code](https://claude.com/claude-code)