### PR TITLE
fix: include CCP_BRANCH_FILE in top-level guard in hook_runner.sh

### DIFF
--- a/lib/hook_runner.sh
+++ b/lib/hook_runner.sh
@@ -29,7 +29,7 @@ mode="${1:-}"
 _dbg "START path=${PATH} status_file=${CCP_STATUS_FILE:-} context_file=${CCP_CONTEXT_FILE:-}"
 
 # Guard: nothing to do if CCP files are not configured
-if [[ -z "${CCP_STATUS_FILE:-}" && -z "${CCP_CONTEXT_FILE:-}" ]]; then
+if [[ -z "${CCP_STATUS_FILE:-}" && -z "${CCP_CONTEXT_FILE:-}" && -z "${CCP_BRANCH_FILE:-}" ]]; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- The top-level early-exit guard in `hook_runner.sh` checked only `CCP_STATUS_FILE` and `CCP_CONTEXT_FILE`, so callers that set only `CCP_BRANCH_FILE` (no status/context files) would exit before reaching the branch detection logic
- Added `&& -z "${CCP_BRANCH_FILE:-}"` to the guard so branch-only usage works correctly

## Test plan
- [ ] `bash tests/test-suite.sh` — all 134 tests pass, including the previously failing `post-tool: branch detection fires without CCP_STATUS_FILE`
- [ ] CI green