### PR TITLE
feat: smart MCP tool classification with action-verb heuristic

### DIFF
--- a/lib/hook_runner.sh
+++ b/lib/hook_runner.sh
@@ -213,6 +213,31 @@ event_status_from_payload() {
     printf '%s' "${status}"
 }
 
+# Classify unknown tools by parsing action verbs from the tool name.
+# MCP tools follow mcp__server__action naming; Claude tools use PascalCase.
+# Returns a status string or empty if no match.
+_classify_tool() {
+    local _tool="$1"
+    # Extract the action part: last segment after __ for MCP, or the full name
+    local _action="${_tool##*__}"
+    # Lowercase for matching (bash 3.2 compat: use tr instead of ${var,,})
+    _action=$(printf '%s' "${_action}" | tr '[:upper:]' '[:lower:]')
+
+    # Order matters: check more specific patterns first (send/comment before
+    # edit/add, since tools like add_issue_comment should be Sending not Editing)
+    if [[ "${_action}" =~ (send|post|comment|message|notify|publish) ]]; then
+        echo "📤 Sending"
+    elif [[ "${_action}" =~ (read|get|list|search|find|query|fetch|resolve|open|tree|info|status|show|view|log|describe) ]]; then
+        echo "📖 Reading"
+    elif [[ "${_action}" =~ (write|create|edit|update|delete|remove|move|rename|add|set|put|insert|replace|push_files|create_or_update) ]]; then
+        echo "✏️ Editing"
+    elif [[ "${_action}" =~ (navigate|click|snapshot|screenshot|hover|fill|select|browse|drag|type|press|resize|tab|install) ]]; then
+        echo "🌐 Browsing"
+    elif [[ "${_action}" =~ (run|execute|eval|invoke) ]]; then
+        echo "🖥️ Running"
+    fi
+}
+
 case "${mode}" in
     pre-tool)
         [[ -z "${CCP_STATUS_FILE:-}" ]] && exit 0
@@ -237,6 +262,9 @@ case "${mode}" in
             Task|Agent)
                 status="🤖 Delegating"
                 ;;
+            ToolSearch)
+                status="📖 Reading"
+                ;;
             Bash)
                 if [[ "${command_str}" =~ (jest|vitest|pytest|mocha|rspec|go[[:space:]]test|cargo[[:space:]]test|phpunit|bun[[:space:]]test|npm[[:space:]]test|yarn[[:space:]]test) ]]; then
                     status="🧪 Testing"
@@ -258,7 +286,8 @@ case "${mode}" in
                 ;;
             *)
                 if [[ -n "${tool}" ]]; then
-                    status="🔧 ${tool}"
+                    status=$(_classify_tool "${tool}")
+                    [[ -z "${status}" ]] && status="🔧 Working"
                 fi
                 ;;
         esac

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -55,7 +55,7 @@ status_to_priority() {
         echo 60
     elif [[ "${status}" =~ (Session\ started|Compacting|Subagent\ started|Teammate\ idle|Config\ changed|Worktree|Notification|Session\ ended) ]]; then
         echo 52
-    elif [[ "${status}" =~ (Reading|Browsing|Running) ]]; then
+    elif [[ "${status}" =~ (Reading|Browsing|Running|Sending|Working) ]]; then
         echo 55
     else
         echo 50

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -338,6 +338,64 @@ result=$(echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
       bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
 assert_equals "Bash generic → 🖥️ Running"    "🖥️ Running"    "${result}"
 
+# pre-tool: ToolSearch (Claude's built-in tool discovery)
+result=$(echo '{"tool_name":"ToolSearch","tool_input":{"query":"slack"}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "ToolSearch → 📖 Reading"       "📖 Reading"    "${result}"
+
+# pre-tool: MCP tool classification (action verb heuristic)
+result=$(echo '{"tool_name":"mcp__filesystem__read_file","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp read_file → 📖 Reading"    "📖 Reading"    "${result}"
+
+result=$(echo '{"tool_name":"mcp__filesystem__list_directory","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp list_directory → 📖 Reading" "📖 Reading"  "${result}"
+
+result=$(echo '{"tool_name":"mcp__github__search_code","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp search_code → 📖 Reading"  "📖 Reading"    "${result}"
+
+result=$(echo '{"tool_name":"mcp__filesystem__write_file","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp write_file → ✏️ Editing"   "✏️ Editing"    "${result}"
+
+result=$(echo '{"tool_name":"mcp__github__create_pull_request","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp create_pull_request → ✏️ Editing" "✏️ Editing" "${result}"
+
+result=$(echo '{"tool_name":"mcp__github__add_issue_comment","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp add_issue_comment → 📤 Sending" "📤 Sending" "${result}"
+
+result=$(echo '{"tool_name":"mcp__playwright__browser_navigate","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp browser_navigate → 🌐 Browsing" "🌐 Browsing" "${result}"
+
+result=$(echo '{"tool_name":"mcp__playwright__browser_click","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp browser_click → 🌐 Browsing"    "🌐 Browsing" "${result}"
+
+result=$(echo '{"tool_name":"mcp__plugin_context7__resolve-library-id","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "mcp resolve-library-id → 📖 Reading" "📖 Reading" "${result}"
+
+# pre-tool: completely unknown tool → generic fallback
+result=$(echo '{"tool_name":"SomeRandomTool","tool_input":{}}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" pre-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "unknown tool → 🔧 Working"     "🔧 Working"    "${result}"
+
 # user-prompt handler
 rm -f "${TMP_CONTEXT}" "${TMP_STATUS}"
 result=$(echo '{"prompt":"Fix the login bug in the auth module"}' \


### PR DESCRIPTION
## Summary

- **Tier 2 — Action-verb heuristic**: Parses MCP tool names (`mcp__server__action`) and classifies by action keywords. Automatically handles filesystem, github, playwright, context7, slack, and any future MCP plugin without config
- **Tier 4 — Clean fallback**: Unknown tools show `🔧 Working` instead of raw tool names like `🔧 mcp__filesystem__list_directory` in the title
- **ToolSearch**: Claude's built-in tool discovery now maps to `📖 Reading`
- **monitor.sh**: `status_to_priority()` updated to recognize `Sending` and `Working`

### Classification rules (checked in order)

| Action contains | Status |
|---|---|
| send, post, comment, message, notify, publish | 📤 Sending |
| read, get, list, search, find, query, fetch, resolve | 📖 Reading |
| write, create, edit, update, delete, add, move, rename | ✏️ Editing |
| navigate, click, snapshot, screenshot, browse, hover | 🌐 Browsing |
| run, execute, eval, invoke | 🖥️ Running |
| *(no match)* | 🔧 Working |

## Test plan

- [x] `bash tests/test-suite.sh` — all 145 tests pass (11 new)
- [x] MCP filesystem tools (read_file, list_directory, write_file) classified correctly
- [x] MCP github tools (search_code, create_pull_request, add_issue_comment) classified correctly
- [x] MCP playwright tools (browser_navigate, browser_click) classified correctly
- [x] MCP context7 tools (resolve-library-id) classified correctly
- [x] Unknown tool (SomeRandomTool) falls back to 🔧 Working
- [x] `shellcheck lib/hook_runner.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)