### PR TITLE
ci: add tag-triggered release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   shellcheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,47 +6,13 @@ on:
       - 'v*'
 
 jobs:
-  shellcheck:
-    name: ShellCheck
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install shellcheck
-        run: brew install shellcheck
-
-      - name: Run shellcheck on all shell files
-        run: |
-          shellcheck --severity=error bin/ccp lib/*.sh install.sh uninstall.sh
-
-  test:
-    name: Test Suite
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: brew install jq
-
-      - name: Run test suite
-        run: bash tests/test-suite.sh
-
-  e2e:
-    name: E2E Tests
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: brew install jq
-
-      - name: Run e2e tests
-        run: FAST=1 bash tests/e2e/run-e2e.sh
+  ci:
+    uses: ./.github/workflows/ci.yml
 
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [shellcheck, test, e2e]
+    needs: [ci]
     permissions:
       contents: write
     steps:
@@ -55,7 +21,8 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --generate-notes


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` — push a `v*` tag and releases happen automatically.

**Flow:** tag push → ShellCheck + tests + e2e (all must pass) → `gh release create` with auto-generated notes from merged PRs since last tag.

No more manually cutting releases.

## Usage going forward

```bash
# bump version in lib/core.sh, commit, then:
git tag v1.x.y
git push origin v1.x.y
# GitHub Actions does the rest
```

## Test plan

- [ ] Merge and push a test tag to verify the workflow triggers and passes
