### PR TITLE
fix: clear stale "Awaiting approval" / "Input needed" after Bash tool completes

### DIFF
--- a/lib/hook_runner.sh
+++ b/lib/hook_runner.sh
@@ -464,7 +464,15 @@ case "${mode}" in
 
         _dbg_event "status_set" "tool=${tool}" "command=$(printf '%s' "${command_str}" | head -c 80)" "status=${status}" "output_preview=$(printf '%s' "${tool_response}" | head -c 120)"
         _dbg "post-tool tool=${tool} status=${status}"
-        [[ -n "${status}" ]] && atomic_write "${CCP_STATUS_FILE}" "${status}"
+        if [[ -n "${status}" ]]; then
+            atomic_write "${CCP_STATUS_FILE}" "${status}"
+        elif [[ -n "${CCP_STATUS_FILE:-}" ]]; then
+            # Clear stale status (e.g. "⏸️ Awaiting approval", "🙋 Input needed")
+            # left by a PermissionRequest/Notification hook that fired async after
+            # PreToolUse.  Tool has now completed — signal idle so the monitor
+            # transitions cleanly instead of staying stuck on the approval state.
+            atomic_write "${CCP_STATUS_FILE}" ""
+        fi
 
         # Detect branch-changing commands and update CCP_BRANCH_FILE so the
         # title monitor can refresh the pane title with the new branch name.

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -445,6 +445,61 @@ result=$(echo '{"tool_name":"Read","tool_input":{},"tool_response":"3 tests pass
       bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
 assert_equals "post-tool: non-Bash leaves status unchanged" "✏️ Editing" "${result}"
 
+# post-tool: stale approval/input states cleared after Bash tool completes
+# Regression: PermissionRequest/Notification hooks fire async and can overwrite
+# the active status set by PreToolUse.  PostToolUse must always write to the
+# status file so these stale states don't persist after the tool finishes.
+
+# Generic Bash (no special output) clears "Awaiting approval" → idle
+printf '⏸️ Awaiting approval' > "${TMP_STATUS}"
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"},"tool_response":"file.txt"}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_empty "post-tool: generic Bash clears stale ⏸️ Awaiting approval" "${result}"
+
+# Generic Bash (no special output) clears "Input needed" → idle
+printf '🙋 Input needed' > "${TMP_STATUS}"
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"cat README.md"},"tool_response":"contents"}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_empty "post-tool: generic Bash clears stale 🙋 Input needed" "${result}"
+
+# Test-pass Bash still writes ✅ even when status was "Awaiting approval"
+printf '⏸️ Awaiting approval' > "${TMP_STATUS}"
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"npm test"},"tool_response":"5 tests passed"}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "post-tool: tests passed overrides stale ⏸️ Awaiting approval" "✅ Tests passed" "${result}"
+
+# Test-fail Bash still writes ❌ even when status was "Awaiting approval"
+printf '⏸️ Awaiting approval' > "${TMP_STATUS}"
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"npm test"},"tool_response":"2 tests failed"}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "post-tool: tests failed overrides stale ⏸️ Awaiting approval" "❌ Tests failed" "${result}"
+
+# Commit Bash still writes 💾 even when status was "Awaiting approval"
+printf '⏸️ Awaiting approval' > "${TMP_STATUS}"
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix\""},"tool_response":"[main abc123] fix"}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "post-tool: commit overrides stale ⏸️ Awaiting approval" "💾 Committed" "${result}"
+
+# Generic Bash (no special output) clears any stale active status → idle
+# (previously would leave e.g. "🖥️ Running" from a prior pre-tool call)
+printf '🖥️ Running' > "${TMP_STATUS}"
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo done"},"tool_response":"done"}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_empty "post-tool: generic Bash clears stale 🖥️ Running on completion" "${result}"
+
+# Non-Bash tools still leave status unchanged (no post-tool writes for Edit/Read/etc.)
+printf '⏸️ Awaiting approval' > "${TMP_STATUS}"
+result=$(echo '{"tool_name":"Edit","tool_input":{},"tool_response":""}' \
+    | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \
+      bash "${LIB_DIR}/hook_runner.sh" post-tool && cat "${TMP_STATUS}" 2>/dev/null || true)
+assert_equals "post-tool: non-Bash (Edit) does not clear status" "⏸️ Awaiting approval" "${result}"
+
 printf '🧪 Testing' > "${TMP_STATUS}"
 result=$(echo '{"tool_name":"Bash","tool_input":{"command":"npm test"},"error":"exit 1"}' \
     | CCP_STATUS_FILE="${TMP_STATUS}" CCP_CONTEXT_FILE="${TMP_CONTEXT}" \


### PR DESCRIPTION
Fixes #30

## Summary

- `PostToolUse` now always writes to the status file after a Bash tool completes
- Specific outcomes (`✅ Tests passed`, `❌ Tests failed`, `💾 Committed`) write their status as before
- All other Bash completions write an empty string, clearing stale `⏸️ Awaiting approval` or `🙋 Input needed` left by async hooks
- Adds 7 regression test cases (156 total, all passing)

## Root cause

`PermissionRequest` and `Notification` hooks are registered as `async: true`, so they often fire *after* `PreToolUse` has already set the correct active status. This overwrites e.g. `🧪 Testing` with `⏸️ Awaiting approval`. When the tool completes, `PostToolUse` only wrote status for specific outcomes — leaving the stale approval state stuck in the title indefinitely.

## What changes

**`lib/hook_runner.sh`** — `post-tool` handler:
```bash
# Before
[[ -n "${status}" ]] && atomic_write "${CCP_STATUS_FILE}" "${status}"

# After
if [[ -n "${status}" ]]; then
    atomic_write "${CCP_STATUS_FILE}" "${status}"
elif [[ -n "${CCP_STATUS_FILE:-}" ]]; then
    # Clear stale status (e.g. "⏸️ Awaiting approval", "🙋 Input needed")
    atomic_write "${CCP_STATUS_FILE}" ""
fi
```

**`tests/test-suite.sh`** — 7 new regression cases:
- Generic Bash clears stale `⏸️ Awaiting approval` → idle
- Generic Bash clears stale `🙋 Input needed` → idle
- `✅ Tests passed` overrides stale `⏸️ Awaiting approval`
- `❌ Tests failed` overrides stale `⏸️ Awaiting approval`
- `💾 Committed` overrides stale `⏸️ Awaiting approval`
- Generic Bash clears stale `🖥️ Running` on completion
- Non-Bash tools (`Edit`, `Read`, etc.) still leave status unchanged

## Test plan

- [x] `bash tests/test-suite.sh` — 156 tests, all passing
- [x] `shellcheck lib/hook_runner.sh` — clean