### PR TITLE
feat: auto-disable dynamic titles in --print mode

### DIFF
--- a/bin/ccp
+++ b/bin/ccp
@@ -284,7 +284,7 @@ main() {
 
             # ── Flags forwarded to Claude ─────────────────────────────────────
             # Flags with no value
-            -c|--continue|\
+            -c|--continue|-p|--print|\
             --dangerously-skip-permissions|--allow-dangerously-skip-permissions|\
             --verbose|--ide|--no-ide|--fork-session|--chrome|--no-chrome|\
             --no-session-persistence|--include-partial-messages|\
@@ -352,6 +352,26 @@ main() {
                 shift
                 ;;
         esac
+    done
+
+    # Auto-disable dynamic titles for non-interactive Claude invocations.
+    # --print / -p is single-turn, stdout-only — no TUI, hooks are meaningless,
+    # and the monitor's OSC escapes would interleave with piped output.
+    # --output-format json/stream-json are similarly non-interactive.
+    local _prev_arg=""
+    for _arg in ${claude_args[@]+"${claude_args[@]}"}; do
+        if [[ "${_arg}" == "--print" || "${_arg}" == "-p" ]]; then
+            enable_dynamic=false
+            log_info "Skipping dynamic titles: --print mode detected"
+            break
+        fi
+        if [[ "${_prev_arg}" == "--output-format" \
+              && ("${_arg}" == "json" || "${_arg}" == "stream-json") ]]; then
+            enable_dynamic=false
+            log_info "Skipping dynamic titles: --output-format ${_arg} detected"
+            break
+        fi
+        _prev_arg="${_arg}"
     done
 
     # Resolve title: explicit arg wins; auto-detect is the default fallback.

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -1029,6 +1029,109 @@ assert_contains "bin/ccp: invalid profile emits clear error" \
 
 rm -rf "${CLI_TMP_DIR}"
 
+# ── Tests: --print mode auto-disables dynamic titles ─────────────────────────
+
+echo ""
+echo "bin/ccp --print mode detection"
+
+BIN_CCP="${PROJECT_DIR}/bin/ccp"
+CLI_TMP_DIR=$(mktemp -d)
+CLI_STATE_DIR="${CLI_TMP_DIR}/state"
+mkdir -p "${CLI_STATE_DIR}"
+CLI_SESSION_FILE="${CLI_STATE_DIR}/sessions.json"
+echo '[]' > "${CLI_SESSION_FILE}"
+
+# --print flag should auto-disable dynamic titles (succeeds without monitor)
+cli_exit=0
+cli_out="${CLI_TMP_DIR}/print-long.out"
+CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
+STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
+"${BIN_CCP}" --print "Summarize this" \
+    >"${cli_out}" 2>&1 || cli_exit=$?
+assert_equals "bin/ccp: --print flag exits 0" "0" "${cli_exit}"
+assert_contains "bin/ccp: --print logs skip message" \
+    "Skipping dynamic titles: --print mode detected" \
+    "$(cat "${cli_out}" 2>/dev/null || true)"
+
+# -p short flag should also auto-disable dynamic titles
+cli_exit=0
+cli_out="${CLI_TMP_DIR}/print-short.out"
+CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
+STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
+"${BIN_CCP}" -p "Summarize this" \
+    >"${cli_out}" 2>&1 || cli_exit=$?
+assert_equals "bin/ccp: -p flag exits 0" "0" "${cli_exit}"
+assert_contains "bin/ccp: -p logs skip message" \
+    "Skipping dynamic titles: --print mode detected" \
+    "$(cat "${cli_out}" 2>/dev/null || true)"
+
+# --print after -- separator should also be detected
+cli_exit=0
+cli_out="${CLI_TMP_DIR}/print-separator.out"
+CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
+STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
+"${BIN_CCP}" "My task" -- --print \
+    >"${cli_out}" 2>&1 || cli_exit=$?
+assert_equals "bin/ccp: --print after -- exits 0" "0" "${cli_exit}"
+assert_contains "bin/ccp: --print after -- logs skip message" \
+    "Skipping dynamic titles: --print mode detected" \
+    "$(cat "${cli_out}" 2>/dev/null || true)"
+
+# Normal args should NOT trigger the skip (dynamic titles still enabled info)
+cli_exit=0
+cli_out="${CLI_TMP_DIR}/normal.out"
+CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
+STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
+"${BIN_CCP}" --no-dynamic "Normal task" \
+    >"${cli_out}" 2>&1 || cli_exit=$?
+assert_equals "bin/ccp: normal args exit 0" "0" "${cli_exit}"
+# Should NOT contain the --print skip message
+if [[ "$(cat "${cli_out}" 2>/dev/null || true)" == *"Skipping dynamic titles: --print mode detected"* ]]; then
+    fail "bin/ccp: normal args should not trigger --print detection"
+else
+    pass "bin/ccp: normal args do not trigger --print detection"
+fi
+
+# --output-format json should auto-disable dynamic titles
+cli_exit=0
+cli_out="${CLI_TMP_DIR}/output-json.out"
+CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
+STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
+"${BIN_CCP}" --output-format json "Summarize this" \
+    >"${cli_out}" 2>&1 || cli_exit=$?
+assert_equals "bin/ccp: --output-format json exits 0" "0" "${cli_exit}"
+assert_contains "bin/ccp: --output-format json logs skip message" \
+    "Skipping dynamic titles: --output-format json detected" \
+    "$(cat "${cli_out}" 2>/dev/null || true)"
+
+# --output-format stream-json should auto-disable dynamic titles
+cli_exit=0
+cli_out="${CLI_TMP_DIR}/output-stream-json.out"
+CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
+STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
+"${BIN_CCP}" --output-format stream-json "Summarize this" \
+    >"${cli_out}" 2>&1 || cli_exit=$?
+assert_equals "bin/ccp: --output-format stream-json exits 0" "0" "${cli_exit}"
+assert_contains "bin/ccp: --output-format stream-json logs skip message" \
+    "Skipping dynamic titles: --output-format stream-json detected" \
+    "$(cat "${cli_out}" 2>/dev/null || true)"
+
+# --output-format text should NOT trigger the skip
+cli_exit=0
+cli_out="${CLI_TMP_DIR}/output-text.out"
+CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
+STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
+"${BIN_CCP}" --output-format text --no-dynamic "Normal task" \
+    >"${cli_out}" 2>&1 || cli_exit=$?
+assert_equals "bin/ccp: --output-format text exits 0" "0" "${cli_exit}"
+if [[ "$(cat "${cli_out}" 2>/dev/null || true)" == *"Skipping dynamic titles: --output-format"* ]]; then
+    fail "bin/ccp: --output-format text should not trigger auto-disable"
+else
+    pass "bin/ccp: --output-format text does not trigger auto-disable"
+fi
+
+rm -rf "${CLI_TMP_DIR}"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 rm -rf "${STATE_DIR}"

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -1077,19 +1077,19 @@ assert_contains "bin/ccp: --print after -- logs skip message" \
     "Skipping dynamic titles: --print mode detected" \
     "$(cat "${cli_out}" 2>/dev/null || true)"
 
-# Normal args should NOT trigger the skip (dynamic titles still enabled info)
+# --no-dynamic disables titles explicitly; should NOT emit auto-detect skip message
 cli_exit=0
 cli_out="${CLI_TMP_DIR}/normal.out"
 CCP_CLAUDE_CMD=/usr/bin/true CCP_STATUS_PROFILE=quiet \
 STATE_DIR="${CLI_STATE_DIR}" SESSION_FILE="${CLI_SESSION_FILE}" \
 "${BIN_CCP}" --no-dynamic "Normal task" \
     >"${cli_out}" 2>&1 || cli_exit=$?
-assert_equals "bin/ccp: normal args exit 0" "0" "${cli_exit}"
-# Should NOT contain the --print skip message
+assert_equals "bin/ccp: --no-dynamic exits 0" "0" "${cli_exit}"
+# Should NOT contain the --print auto-detect skip message
 if [[ "$(cat "${cli_out}" 2>/dev/null || true)" == *"Skipping dynamic titles: --print mode detected"* ]]; then
-    fail "bin/ccp: normal args should not trigger --print detection"
+    fail "bin/ccp: --no-dynamic should not trigger --print auto-detection message"
 else
-    pass "bin/ccp: normal args do not trigger --print detection"
+    pass "bin/ccp: --no-dynamic does not trigger --print auto-detection message"
 fi
 
 # --output-format json should auto-disable dynamic titles


### PR DESCRIPTION
## Summary
- Detects `--print` / `-p` in `claude_args` after parsing and auto-sets `enable_dynamic=false`
- Also detects `--output-format json` and `--output-format stream-json` (similarly non-interactive)
- Skips monitor startup, hook setup, and startup display block when detected
- Claude still runs normally with all args passed through
- Logs an informational message when dynamic titles are skipped

## Test plan
- [x] `--print` flag detected correctly (exits 0, logs skip message)
- [x] `-p` short flag detected correctly
- [x] `--print` after `--` separator detected correctly
- [x] Normal args do not trigger the skip
- [x] `--output-format json` triggers auto-disable
- [x] `--output-format stream-json` triggers auto-disable
- [x] `--output-format text` does not trigger auto-disable
- [x] All 179 tests pass (14 new)
- [x] ShellCheck clean

Closes #15