### PR TITLE
feat: Herdr pane rename + title metadata on set_title

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Running multiple Claude Code agents in split panes? Without ccp every pane shows a generic title — you have to read the terminal output to know what's happening in each one. With ccp, the title bar tells you.
 
+**Herdr support:** when running inside Herdr (`HERDR_ENV=1`), ccp also renames the Herdr pane and publishes `pane.report-metadata` on base task title updates so the Herdr sidebar stays aligned with the terminal title.
+
 ![Four iTerm2 split panes with ccp — each title bar independently showing project, branch, task, and live status](docs/screenshots/demo-4pane.gif)
 
 Each pane updates on its own schedule. When one agent finishes and commits, that pane flips to `💾 Committed`. The others keep going.

--- a/lib/title.sh
+++ b/lib/title.sh
@@ -87,9 +87,43 @@ _ccp_write_title() {
     esac
 }
 
+# When running under Herdr, also rename the pane and publish title metadata.
+# Only call this from set_title (base task titles), not from high-frequency
+# update_title_with_context status spinners.
+# Fail open: never break OSC title updates if herdr is missing or errors.
+_ccp_herdr_pane_rename() {
+    local title="$1"
+    [[ "${HERDR_ENV:-}" == "1" ]] || return 0
+    [[ -n "${HERDR_PANE_ID:-}" ]] || return 0
+    [[ -n "${title}" ]] || return 0
+
+    local herdr_bin="${HERDR_BIN_PATH:-herdr}"
+    command -v "${herdr_bin}" >/dev/null 2>&1 || return 0
+
+    # Keep pane labels short and stable (strip common spinner/status prefixes).
+    local pane_title
+    pane_title="$(printf '%s' "${title}" | sed -E 's/^[[:space:]]*[\|•●○◐◑◒◓✓✗\*\?▶▷]+[[:space:]]*//' | head -c 60)"
+    [[ -n "${pane_title}" ]] || return 0
+
+    # Debounce identical titles so rapid set_title calls don't spam herdr.
+    if [[ "${_CCP_LAST_HERDR_TITLE:-}" == "${pane_title}" ]]; then
+        return 0
+    fi
+    _CCP_LAST_HERDR_TITLE="${pane_title}"
+
+    "${herdr_bin}" pane rename "${HERDR_PANE_ID}" "${pane_title}" >/dev/null 2>&1 || true
+    "${herdr_bin}" pane report-metadata "${HERDR_PANE_ID}" \
+        --source "plugin:claude-code-pulse" \
+        --title "${pane_title}" \
+        --display-agent "${pane_title}" \
+        --token "task=${pane_title}" \
+        --ttl-ms 86400000 >/dev/null 2>&1 || true
+}
+
 set_title() {
     local title="$1"
     _ccp_write_title "${title}"
+    _ccp_herdr_pane_rename "${title}"
 
     # CCP_TITLE_LOG: append each title to a log file (used by e2e tests).
     # Use || true so a bad/unwritable path never terminates ccp under set -e.


### PR DESCRIPTION
## Summary

Closes / addresses brianruggieri/claude-code-pulse#43

Adds **Herdr pane renaming + title metadata** on top of this project's existing tab/title/agent rename behavior.

### Why

Herdr official integrations report agent lifecycle only. They do not publish task-derived pane titles. Without plugins filling that gap, multi-agent Herdr sidebars stay unreadable even when outer terminal titles are correct.

Related upstream: https://github.com/ogulcancelik/herdr/discussions/1725

### What changed

On `set_title` (base task titles), also rename the Herdr pane and publish metadata. High-frequency `update_title_with_context` status lines are intentionally left alone.

### Behavior

- Existing title/rename path is unchanged for non-Herdr sessions
- Under Herdr (`HERDR_ENV=1` / plugin context), also:
  - `herdr pane rename`
  - `herdr pane report-metadata --title --display-agent --token task=...`
- Fail open: Herdr failures never break the original title path

### Test plan

- [ ] Non-Herdr: existing title/rename behavior unchanged
- [ ] Under Herdr: after a task title is set, `herdr pane get $HERDR_PANE_ID` shows updated label/metadata title
- [ ] High-frequency status updates do not thrash pane names (where applicable)
- [ ] Missing `herdr` binary does not error the main path
